### PR TITLE
Get .team-matcha-secrets from home

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,3 +6,6 @@ docker-up:
 
 docker-test:
 	docker-compose exec server python manage.py test
+
+docker-recreate-db:
+	docker-compose exec server python manage.py recreate_db

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ make docker-test
 
 #### To Create Table:
 ```
-docker-compose exec server python manage.py create_db
+make docker-recreate-db
 ```
 
 #### To enter postgres terminal:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,7 +28,7 @@ services:
     environment:
       - APP_SETTINGS=project.config.DevelopmentConfig
     env_file:
-      - ./server/.env
+      - "~/.team-matcha-secrets"
     depends_on:
       - postgres-db
 

--- a/server/manage.py
+++ b/server/manage.py
@@ -8,9 +8,9 @@ import sys
 cli = FlaskGroup(create_app=create_app)
 
 
-@cli.command("create_db")
+@cli.command("recreate_db")
 def create_db():
-    print("Creating db")
+    print("Recreating db")
     db.drop_all()
     db.create_all()
     db.session.commit()


### PR DESCRIPTION
Since .env files are gitignored, moving where docker gets env from.

Please make a .team-matcha-secrets file with the contents of .env and put it in your home directory.